### PR TITLE
Fix unexpected quitting when workflowGuid is undefined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,13 +319,13 @@ module.exports = {
         }
         function element(k, v) {
           xml += '<' + k;
-          if (v._attributes) {
+          if (v && v._attributes) {
             _.each(v._attributes, function(av, a) {
               xml += ' ' + a + '="' + self.apos.utils.escapeHtml(av) + '"';
             });
           }
           xml += '>';
-          xml += self.stringify(v);
+          xml += self.stringify(v || '');
           xml += '</' + k + '>\n';
         }
       });


### PR DESCRIPTION
When workflowGuid is not set, v is not set and v._attributes will quit the execution.