### PR TITLE
Maps over the default array when only one file

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ module.exports = {
       if (!self.perLocale) {
         // Simple single-file sitemap
         self.file = self.caching ? 'sitemap.xml' : (self.apos.argv.file || '/dev/stdout');
-        var map = _.map(self.maps, self.stringify).join('\n');
+        var map = _.map(self.maps.default, self.stringify).join('\n');
         self.writeMap(self.file, map);
       } else {
         // They should be broken down by host,


### PR DESCRIPTION
Attempting to map over the maps object resulted in the bug #9. When only one site it looks like the default array is what we need. This fixed it for my site.