### PR TITLE
support for the newly exported test destroy function from apostrophe,…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "apostrophe": "^2.41.0",
     "apostrophe-workflow": "^2.4.1",
-    "mocha": "^5.1.0"
+    "mocha": "^3.5.3"
   },
   "scripts": {
     "test": "mocha test/test-workflow.js && mocha test/test-simple.js"

--- a/test/test-simple.js
+++ b/test/test-simple.js
@@ -10,8 +10,14 @@ describe('Apostrophe Sitemap: simple site without workflow', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    try {
+      require('apostrophe/test-lib/util').destroy(apos, done);
+    } catch (e) {
+      console.warn('Old version of apostrophe does not export test-lib/util library, just dropping old test db');
+      apos.db.dropDatabase();
+      setTimeout(done, 1000);
+    }
   });
 
   it('should be a property of the apos object', function(done) {

--- a/test/test-workflow.js
+++ b/test/test-workflow.js
@@ -10,8 +10,14 @@ describe('Apostrophe Sitemap: workflow: hostname and prefixes with perLocale', f
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    try {
+      require('apostrophe/test-lib/util').destroy(apos, done);
+    } catch (e) {
+      console.warn('Old version of apostrophe does not export test-lib/util library, just dropping old test db');
+      apos.db.dropDatabase();
+      setTimeout(done, 1000);
+    }
   });
 
   it('perLocale: should be a property of the apos object', function(done) {
@@ -208,8 +214,14 @@ describe('Apostrophe Sitemap: workflow: hostname and prefixes without perLocale'
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    try {
+      require('apostrophe/test-lib/util').destroy(apos, done);
+    } catch (e) {
+      console.warn('Old version of apostrophe does not export test-lib/util library, just dropping old test db');
+      apos.db.dropDatabase();
+      setTimeout(done, 1000);
+    }
   });
 
   it('should initialize', function(done) {
@@ -385,8 +397,14 @@ describe('Apostrophe Sitemap: workflow: legacy subdomains option', function() {
   var apos;
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    try {
+      require('apostrophe/test-lib/util').destroy(apos, done);
+    } catch (e) {
+      console.warn('Old version of apostrophe does not export test-lib/util library, just dropping old test db');
+      apos.db.dropDatabase();
+      setTimeout(done, 1000);
+    }
   });
 
   it('should be a property of the apos object', function(done) {


### PR DESCRIPTION
… but also fallback support and a dev dep on mocha 3 to work around this for now.

This is about cleaning up resources so that mocha 5 exits properly when we end our tests. mocha 5 will not let you get away with sloppy tests of code that leaves timeouts, open files, etc. lying around, which is a *good* thing. But until the corresponding update ships in apostrophe we'll leave the mocha dependency at 3 for bc.