### PR TITLE
Specifies undeclared variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.1
+
+Fixes a bug in the `exclude-types` argument usage.
+
 ## 2.5.0
 
 Added a configuration option to remove `siteMapPriority` field globally

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ modules: {
 
 ## Changelog
 
+2.4.7: Fixes a bug in the `exclude-types` argument usage.
+
 2.4.6: never generate a priority below 0.1.
 
 2.4.5: clone the priority field before adding it so we do not get into issues with `arrangeFields`.

--- a/index.js
+++ b/index.js
@@ -69,10 +69,6 @@ module.exports = {
 
       var argv = self.apos.argv;
 
-      if (argv['exclude-types']) {
-        self.excludeTypes = self.excludeTypes.concat(argv['exclude-types'].split(','));
-      }
-
       if (self.caching) {
         self.cacheOutput = [];
       }
@@ -93,7 +89,13 @@ module.exports = {
         self.format = argv.format || options.format || 'xml';
 
         self.indent = (typeof(argv.indent) !== 'undefined') ? argv.indent : options.indent;
+
         self.excludeTypes = options.excludeTypes || [];
+
+        if (argv['exclude-types']) {
+          self.excludeTypes = self.excludeTypes.concat(argv['exclude-types'].split(','));
+        }
+
         self.perLocale = options.perLocale || argv['per-locale'];
         // Exception: plaintext sitemaps and sitemap indexes don't go
         // together, so we can presume that if they explicitly ask

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = {
       var argv = self.apos.argv;
 
       if (argv['exclude-types']) {
-        self.excludeTypes = excludeTypes.concat(argv['exclude-types'].split(','));
+        self.excludeTypes = self.excludeTypes.concat(argv['exclude-types'].split(','));
       }
 
       if (self.caching) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-site-map",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Generate site maps for sites powered by the Apostrophe CMS.",
   "main": "index.js",
   "dependencies": {
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/punkave/apostrophe-site-map"
+    "url": "https://github.com/apostrophecms/apostrophe-site-map"
   },
   "keywords": [
     "sitemap",
@@ -32,7 +32,7 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/punkave/apostrophe-site-map/issues"
+    "url": "https://github.com/apostrophecms/apostrophe-site-map/issues"
   },
-  "homepage": "https://github.com/punkave/apostrophe-site-map"
+  "homepage": "https://github.com/apostrophecms/apostrophe-site-map"
 }


### PR DESCRIPTION
eslint flagged this for me while I was looking at another issue. It was either `self` or `options` and it seems like `self` was intended here.