### PR TITLE
Ignores workflow needs for deleting props

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,17 +168,18 @@ module.exports = {
         each(function(entry) {
           delete entry.url.workflowLocale;
           delete entry.url.workflowGuid;
-        });
+        }, true);
 
         return setImmediate(callback);
 
-        function each(iterator) {
+        function each(iterator, ignoreWorkflow) {
           _.each(self.maps, function(map) {
             _.each(map, function(entry) {
               if (typeof(entry) !== 'object') {
                 return;
               }
-              if (!entry.url.workflowGuid) {
+
+              if (!entry.url.workflowGuid && !ignoreWorkflow) {
                 return;
               }
               iterator(entry);


### PR DESCRIPTION
For #17 

Lets the step of removing workflow properties to ignore the check for a workflowGuid.