### PR TITLE
Add possibility to configure baseUrl only for the sitemaps module

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,24 @@ This module generates a sitemap that includes all of the pages on your site that
 }
 ```
 
+#### Alternative configuration
+
+If you don't like to modify/overwrite the baseUrl for the site or keep the site without a baseUrl, you can add baseUrl in the configuration of the module:
+
+```javascript
+{
+  // No baseUrl here
+  modules: {
+    {
+      'apostrophe-site-map': {
+        baseUrl: 'http://example.com',
+        excludeTypes: []
+      }
+    }
+  }
+}
+```
+
 * Just launch your site as you normally would. In development that might just be:
 
 ```

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = {
         self.caching = false;
       }
 
-      if (!apos.options.baseUrl) {
+      if (!self.baseUrl) {
         return callback(new Error(
           'You must specify the top-level baseUrl option when configuring Apostrophe\n' +
           'to use this task. Example: baseUrl: "http://mycompany.com"\n\n' +

--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ module.exports = {
 
     self.piecesPerBatch = options.piecesPerBatch;
 
+    self.baseUrl = options.baseUrl || self.apos.baseUrl;
+
     self.clearTask = function(apos, argv, callback) {
       // Just forget the current sitemaps to make room
       // for regeneration on the next request
@@ -348,7 +350,7 @@ module.exports = {
 
     self.writeIndex = function() {
       var now = new Date();
-      if (!self.apos.baseUrl) {
+      if (!self.baseUrl) {
         throw new Error(
           'You must specify the top-level baseUrl option when configuring Apostrophe\n' +
           'to use sitemap indexes. Example: baseUrl: "http://mycompany.com"\n\n' +
@@ -364,7 +366,7 @@ module.exports = {
         _.map(_.keys(self.maps), function(key) {
           var map = self.maps[key];
           var sitemap = '  <sitemap>\n' +
-            '    <loc>' + self.apos.baseUrl + self.apos.prefix + '/sitemaps/' + key + '.xml'
+            '    <loc>' + self.baseUrl + self.apos.prefix + '/sitemaps/' + key + '.xml'
               + '</loc>\n' +
             '    <lastmod>' + now.toISOString() + '</lastmod>\n' +
           '  </sitemap>\n';


### PR DESCRIPTION
This PR makes it possible to only configure baseUrl for the sitemap without adding a baseUrl for the entire site.

There can be situations where you would want to leave the site domain(s) as is, but then it's impossible to use this module.