### PR TITLE
Prevents negative priority number and trims value

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,8 +143,12 @@ function Construct(options, callback) {
           }
           fs.writeSync(out, page.slug);
         } else {
+          var pageLevel = (1.0 - page.level / 10);
+          if (pageLevel < 0) {
+            pageLevel = 0.0;
+          }
           var url = (trustUrl && page.url) || (host + (site.prefix || '') + page.slug);
-          fs.writeSync(out, '  <url><priority>' + (1.0 - page.level / 10) + '</priority><changefreq>daily</changefreq><loc>' + url + '</loc></url>\n');
+          fs.writeSync(out, '  <url><priority>' + pageLevel.toFixed(1) + '</priority><changefreq>daily</changefreq><loc>' + url + '</loc></url>\n');
         }
         _.each(page.children, function(page) {
           output(page);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "apostrophe-site-map",
+  "version": "0.5.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+    },
+    "moment": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
+      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+    }
+  }
+}


### PR DESCRIPTION
Integrity Staffing was getting invalid priority levels in their sitemap because they have some deeply nested pages.

This is specifically to fix this in 0.5 but it looks like it could be an issue for newer sites too. 