### PR TITLE
Rename init test for hreflang test group

### DIFF
--- a/test/test-workflow.js
+++ b/test/test-workflow.js
@@ -467,7 +467,7 @@ describe('Apostrophe Sitemap: workflow: single sitemap with hreflang alternative
     }
   });
 
-  it('perLocale: should be a property of the apos object', function(done) {
+  it('should initialize', function(done) {
     apos = require('apostrophe')({
       testModule: true,
       baseUrl: 'http://localhost:7790',


### PR DESCRIPTION
This is very minor, but I copied the initialization test from another `describe` group, and accidentally left the same name for the `it` test, which doesn't make sense