### PR TITLE
Sup 183 create method providing pages tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Adds new `getPagesTree` method that returns the nested pages in the right order with pieces that are also pages. To be able to build a sitemap page from any project.
+
 ## 2.6.0 (2021-10-13)
 
 Introduced a `rewriteUrl` method, which project developers can override to customize the URLs being output in the sitemap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Adds new `getPagesTree` method that returns the nested pages in the right order with pieces that are also pages. To be able to build a sitemap page from any project.
+Adds new `getPageTree` method that returns the nested pages in the right order with pieces that are also pages. To be able to build a sitemap page from any project.
 
 ## 2.6.0 (2021-10-13)
 

--- a/README.md
+++ b/README.md
@@ -257,8 +257,12 @@ module.exports = {
     };
   }
 };
+```
 
+## Getting the page tree programmatically
 
-## Getting pages tree
+This module's primary purpose is creating a sitemap for Google and other search engines, but it is also useful in creating a sitemap for end users.
 
-In order to build a sitemap page, you can use the method `self.getPagesTree` from this module. It returns the nested pages and pieces pages in the right order. For each page you can access the array `_children` recursively to render the pages links at the right level.
+In order to build a sitemap page, you can use the method `self.getPageTree` from this module. It returns the nested pages and pieces pages in the right order. For each page you can access the array `_children` recursively to render the pages links at the right level.
+
+This method has a large performance impact each time it is called on a site with a large page tree, or many pieces reachable via pieces-pages. Strongly consider caching the response for a period of time.

--- a/README.md
+++ b/README.md
@@ -257,3 +257,8 @@ module.exports = {
     };
   }
 };
+
+
+## Getting pages tree
+
+In order to build a sitemap page, you can use the method `self.getPagesTree` from this module. It returns the nested pages and pieces pages in the right order. For each page you can access the array `_children` recursively to render the pages links at the right level.

--- a/README.md
+++ b/README.md
@@ -266,3 +266,15 @@ This module's primary purpose is creating a sitemap for Google and other search 
 In order to build a sitemap page, you can use the method `self.getPageTree` from this module. It returns the nested pages and pieces pages in the right order. For each page you can access the array `_children` recursively to render the pages links at the right level.
 
 This method has a large performance impact each time it is called on a site with a large page tree, or many pieces reachable via pieces-pages. Strongly consider caching the response for a period of time.
+
+It is possible to exclude some pages or pieces types only for the page tree, without impacting the normal `sitemap.xml` generation.
+The `excludeTypes` option will exclude types from the sitemap file and from the `getPageTree` method.
+The `excludeTypesFromPageTree` option will exclude types only from the `getPageTree` method.
+
+```javascript
+  {
+    'apostrophe-site-map': {
+      excludeTypesFromPageTree: [ 'article' ]
+    }
+  }
+```

--- a/index.js
+++ b/index.js
@@ -594,7 +594,8 @@ module.exports = {
     self.getPageTree = async (req) => {
       const excludedTypes = [
         'workflow-document',
-        ...self.options.excludeTypes || []
+        ...self.options.excludeTypes || [],
+        ...self.options.excludeTypesFromPageTree || [],
       ]
 
       const pages = await getPages();

--- a/index.js
+++ b/index.js
@@ -592,7 +592,6 @@ module.exports = {
     };
 
     self.getPageTree = async (req) => {
-      self.maps = {};
       const excludedTypes = [
         'workflow-document',
         ...self.options.excludeTypes || []
@@ -601,7 +600,7 @@ module.exports = {
       const pages = await getPages();
       const pagesWithPieces = await getPieces(pages);
 
-      return pagesWithPieces;
+      return rewriteUrls(pagesWithPieces);
 
       async function getPages () {
         try {
@@ -708,6 +707,19 @@ module.exports = {
             ]
           }, [])
         }
+      }
+
+      function rewriteUrls (pages = []) {
+        return pages.reduce((acc, page) => {
+          return [
+            ...acc,
+            {
+              ...page,
+              _url: self.rewriteUrl(page._url),
+              _children: rewriteUrls(page._children)
+            }
+          ]
+        }, [])
       }
     };
   }

--- a/index.js
+++ b/index.js
@@ -687,8 +687,6 @@ module.exports = {
               return;
             }
 
-              console.log('fetchedPieces[0] ===> ', require('util').inspect(fetchedPieces[0], { colors: true, depth: 2 }))
-
             fetchedPieces.forEach(piece => {
               if (piece._url && !excludedTypes.includes(piece.type)) {
                 modulePieces.push(piece);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-site-map",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Generate site maps for sites powered by the Apostrophe CMS.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
[SUP-183](https://apostrophecms.atlassian.net/jira/software/c/projects/IN/boards/38?modal=detail&selectedIssue=SUP-183)

## Summary
Adds a new method `self.getPagesTree` that returns all the pages for the current locale, with children and in the right order. Also gets pieces that are pages in the tree. It allows to easily build a sitemap page in any project.
Should be tested with [this PR](https://github.com/WeAreScottie/scottie-app/pull/718/files)

## What are the specific steps to test this change?

> 1. Go on [this branch](https://github.com/WeAreScottie/scottie-app/pull/718/files).
> 2. npm link this module from this branch.
> 3. Create a page of type sitemap
> 4. Checks if on this page, sitemap links are properly rendered.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [X] Related documentation has been updated
- [ ] Related tests have been updated
